### PR TITLE
Fix comment typo

### DIFF
--- a/libs/Tokenizer/SyntaxTree.class.php
+++ b/libs/Tokenizer/SyntaxTree.class.php
@@ -23,7 +23,7 @@ class syntaxTree {
 
 	/**
 	 * 
-	 * @param int $idx the origian stream array key
+         * @param int $idx the original stream array key
 	 * @param array $token parent (opening) token
 	 * @return array
 	 * @throws \Exception


### PR DESCRIPTION
## Summary
- correct a comment in `SyntaxTree.class.php` so it reads "original stream array key"

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688283d4f2b4832f94aae369359aa366